### PR TITLE
Fixed HTTP gems mock

### DIFF
--- a/lib/webmock/http_lib_adapters/http_gem/streamer.rb
+++ b/lib/webmock/http_lib_adapters/http_gem/streamer.rb
@@ -5,8 +5,20 @@ module HTTP
         @io = StringIO.new str
       end
 
-      def readpartial(size = HTTP::Client::BUFFER_SIZE)
+      def readpartial(size = nil)
+        unless size
+          if defined?(HTTP::Client::BUFFER_SIZE)
+            size = HTTP::Client::BUFFER_SIZE
+          elsif defined?(HTTP::Connection::BUFFER_SIZE)
+            size = HTTP::Connection::BUFFER_SIZE
+          end
+        end
+
         @io.read size
+      end
+
+      def sequence_id
+        -1
       end
     end
   end


### PR DESCRIPTION
With http 0.8.0.pre the format changed slightly, this makes it work with both pre-0.8 and post.

cc @ixti @tarcieri
